### PR TITLE
fix(web): 调整LoRA滑块的取值范围和步长

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 *.pyc
 
 # LoRA trigger words config (user-specific, varies per machine)
-lora_trigger_words.json
+nodes/lora_trigger_words.json
 
 # Local docs (plans, notes, etc.)
 docs/

--- a/web/lora_prompt_encoder.js
+++ b/web/lora_prompt_encoder.js
@@ -1055,9 +1055,9 @@ async function initNodeUI(node) {
             // 强度滑块
             const strengthSlider = el("input", {
                 type: "range",
-                min: "0",
+                min: "-3",
                 max: "4",
-                step: "0.01",
+                step: "0.1",
                 value: item.strength.toString(),
                 disabled: !isEnabled,
                 style: {
@@ -1103,7 +1103,7 @@ async function initNodeUI(node) {
                 onClick: (e) => {
                     e.stopPropagation();
                     if (!isEnabled) return;
-                    item.strength = Math.max(0, +(item.strength - 0.01).toFixed(2));
+                    item.strength = Math.max(-3, +(item.strength - 0.5).toFixed(2));
                     strengthInput.value = item.strength.toFixed(2);
                     strengthSlider.value = item.strength.toString();
                     syncToWidget();
@@ -1134,7 +1134,7 @@ async function initNodeUI(node) {
                 onInput: (e) => {
                     let val = parseFloat(e.target.value);
                     if (isNaN(val)) return;
-                    val = Math.max(0, Math.min(4, val));
+                    val = Math.max(-3, Math.min(4, val));
                     item.strength = val;
                     strengthSlider.value = val.toString();
                     syncToWidget();
@@ -1142,7 +1142,7 @@ async function initNodeUI(node) {
                 onBlur: (e) => {
                     let val = parseFloat(e.target.value);
                     if (isNaN(val)) val = 1.0;
-                    val = Math.max(0, Math.min(4, val));
+                    val = Math.max(-3, Math.min(4, val));
                     item.strength = val;
                     e.target.value = val.toFixed(2);
                     strengthSlider.value = val.toString();
@@ -1172,7 +1172,7 @@ async function initNodeUI(node) {
                 onClick: (e) => {
                     e.stopPropagation();
                     if (!isEnabled) return;
-                    item.strength = Math.min(4, +(item.strength + 0.01).toFixed(2));
+                    item.strength = Math.min(4, +(item.strength + 0.5).toFixed(2));
                     strengthInput.value = item.strength.toFixed(2);
                     strengthSlider.value = item.strength.toString();
                     syncToWidget();


### PR DESCRIPTION
1. 将滑块最小值从0改为-3，支持负强度调整
2. 将步长从0.01改为0.1，优化交互体验
3. 更新相关的数值校验和增减逻辑适配新的参数范围
4. 修正.gitignore中LoRA配置文件的路径