### PR TITLE
fix(web/ps_sync_on_run): 隐藏GetImageFromPS的文件名输入控件

### DIFF
--- a/web/ps_sync_on_run.js
+++ b/web/ps_sync_on_run.js
@@ -204,6 +204,16 @@ async function syncBeforeRun() {
 app.registerExtension({
     name: "Comfyui-txtnode.PSSyncOnRun",
 
+    // 隐藏 GetImageFromPS 的文件名控件（文件名由本扩展自动注入，无需用户填写）
+    nodeCreated(node) {
+        if (node.comfyClass !== TARGET_NODE && node.type !== TARGET_NODE) return;
+        for (const w of node.widgets || []) {
+            if (w.name === "image_filename" || w.name === "mask_filename") {
+                w.hidden = true;
+            }
+        }
+    },
+
     async setup() {
         const origQueuePrompt = app.queuePrompt;
         if (!origQueuePrompt) {


### PR DESCRIPTION
当节点创建时自动隐藏image_filename和mask_filename控件，这些文件名将由扩展自动注入，无需用户手动填写